### PR TITLE
Add second chart to display sleep quality over week

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -36,7 +36,8 @@
           </section>
         </section>
         <section class="chart-container" id="chartContainer">
-            <canvas id="myChart"></canvas>
+            <canvas id="hoursSleptOverWeek"></canvas>
+            <canvas id="sleepQualityOverWeek"></canvas>
         </section>
         <section class="widget-container" id="widgetContainer">
           <!-- <h4>widgets go in here</h4> -->

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -1,8 +1,10 @@
 import Chart from "chart.js/auto";
 
-const myChart = document.getElementById("myChart");
+const myChart = document.getElementById("hoursSleptOverWeek");
 
-const buildSleepChart = (userData) => {
+const mySecondChart = document.getElementById("sleepQualityOverWeek");
+
+const hoursSleptOverWeekChart = (userData) => {
   const sleepChart = new Chart(myChart, {
     type: "bar",
     data: {
@@ -17,7 +19,7 @@ const buildSleepChart = (userData) => {
       ],
       datasets: [
         {
-          label: "hours slept",
+          label: "Hours Slept",
           data: [
             userData[0].hoursSlept,
             userData[1].hoursSlept,
@@ -41,4 +43,44 @@ const buildSleepChart = (userData) => {
   });
 };
 
-export { buildSleepChart };
+const sleepQualityOverWeekChart = (userData) => {
+  const sleepChart = new Chart(mySecondChart, {
+    type: "bar",
+    data: {
+      labels: [
+        `${userData[0].date}`,
+        `${userData[1].date}`,
+        `${userData[2].date}`,
+        `${userData[3].date}`,
+        `${userData[4].date}`,
+        `${userData[5].date}`,
+        `${userData[6].date}`,
+      ],
+      datasets: [
+        {
+          label: "Sleep Quality",
+          data: [
+            userData[0].sleepQuality,
+            userData[1].sleepQuality,
+            userData[2].sleepQuality,
+            userData[3].sleepQuality,
+            userData[4].sleepQuality,
+            userData[5].sleepQuality,
+            userData[6].sleepQuality,
+          ],
+          borderWidth: 1,
+        },
+      ],
+    },
+    options: {
+      scales: {
+        y: {
+          beginAtZero: true,
+        },
+      },
+    },
+  });
+};
+
+export { hoursSleptOverWeekChart };
+export {sleepQualityOverWeekChart};

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -8,7 +8,8 @@ import Sleep from "./Sleep";
 import { fetchUserData } from "./apiCalls";
 import { fetchSleepData } from "./apiCalls";
 import { fetchHydrationData } from "./apiCalls";
-import { buildSleepChart } from "./Chart";
+import { hoursSleptOverWeekChart } from "./Chart";
+import { sleepQualityOverWeekChart } from "./Chart";
 
 // query selectors 👇🏻
 
@@ -140,5 +141,6 @@ const displayAvgAllTime = () => {
 
 const displaySleepChart = () => {
   const usersSleepOverWeek = userSleepData.getUserData(1).slice(-7);
-  buildSleepChart(usersSleepOverWeek);
+  hoursSleptOverWeekChart(usersSleepOverWeek);
+  sleepQualityOverWeekChart(usersSleepOverWeek);
 };


### PR DESCRIPTION
#### What's this PR do?
- This will add a second sleep chart that displays the sleep quality for a user over the last 7 days
#### Where should the reviewer start?
- Run `npm install chart.js` if you haven't already
- Chart.js
- index.html
- scripts.js
#### How should this be manually tested?
- Run `npm start` and navigate to http://localhost:8080/ in your browser
- Confirm that two charts are displayed on the DOM
#### Any background context you want to provide?
n/a
#### What are the relevant tickets?
n/a
#### Screenshots (if appropriate)
n/a
#### Questions:
n/a